### PR TITLE
import "" as NA_character_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .readsas_unc_tmp_file
+.DS_Store
 .Rproj.user
 .Rhistory
 .RData

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -7,6 +7,7 @@
 #' @param debug print debug information
 #' @param selectrows_ integer vector of selected rows
 #' @param selectcols_ character vector of selected rows
+#' @param empty_to_na logical convert '' to NA_character_
 #' @import Rcpp
 #' @export
 readsas <- function(filePath, debug, selectrows_, selectcols_, empty_to_na) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,7 +9,7 @@
 #' @param selectcols_ character vector of selected rows
 #' @import Rcpp
 #' @export
-readsas <- function(filePath, debug, selectrows_, selectcols_) {
-    .Call(`_readsas_readsas`, filePath, debug, selectrows_, selectcols_)
+readsas <- function(filePath, debug, selectrows_, selectcols_, empty_to_na) {
+    .Call(`_readsas_readsas`, filePath, debug, selectrows_, selectcols_, empty_to_na)
 }
 

--- a/R/readsas.R
+++ b/R/readsas.R
@@ -12,6 +12,8 @@
 #'@param select.cols \emph{character:} Vector of variables to select.
 #'@param remove_deleted logical if deleted rows should be removed from data
 #'@param rownames first column will be used as rowname and removed from data
+#'@param empty_to_na logical. In SAS empty characters are missing. this option
+#' allows to convert `""` to `NA_character_` when importing.
 #'
 #'@useDynLib readsas, .registration=TRUE
 #'@importFrom utils download.file
@@ -20,7 +22,7 @@
 #'@export
 read.sas <- function(file, debug = FALSE, convert_dates = TRUE, recode = TRUE,
                      select.rows = NULL, select.cols = NULL, remove_deleted = TRUE,
-                     rownames = FALSE) {
+                     rownames = FALSE, empty_to_na = FALSE) {
 
   # Check if path is a url
   if (length(grep("^(http|ftp|https)://", file))) {
@@ -70,7 +72,7 @@ read.sas <- function(file, debug = FALSE, convert_dates = TRUE, recode = TRUE,
     return(message("select.cols must be of type character"))
   }
 
-  data <- readsas(filepath, debug, select.rows, select.cols)
+  data <- readsas(filepath, debug, select.rows, select.cols, empty_to_na)
 
 
   # rowcount <- attr(data, "rowcount")

--- a/man/read.sas.Rd
+++ b/man/read.sas.Rd
@@ -12,7 +12,8 @@ read.sas(
   select.rows = NULL,
   select.cols = NULL,
   remove_deleted = TRUE,
-  rownames = FALSE
+  rownames = FALSE,
+  empty_to_na = FALSE
 )
 }
 \arguments{
@@ -33,6 +34,9 @@ the rows in range will be selected.}
 \item{remove_deleted}{logical if deleted rows should be removed from data}
 
 \item{rownames}{first column will be used as rowname and removed from data}
+
+\item{empty_to_na}{logical. In SAS empty characters are missing. this option
+allows to convert `""` to `NA_character_` when importing.}
 }
 \description{
 read.sas

--- a/man/readsas.Rd
+++ b/man/readsas.Rd
@@ -4,7 +4,7 @@
 \alias{readsas}
 \title{Reads SAS data files}
 \usage{
-readsas(filePath, debug, selectrows_, selectcols_)
+readsas(filePath, debug, selectrows_, selectcols_, empty_to_na)
 }
 \arguments{
 \item{filePath}{The full systempath to the sas7bdat file you want to import.}

--- a/man/readsas.Rd
+++ b/man/readsas.Rd
@@ -14,6 +14,8 @@ readsas(filePath, debug, selectrows_, selectcols_, empty_to_na)
 \item{selectrows_}{integer vector of selected rows}
 
 \item{selectcols_}{character vector of selected rows}
+
+\item{empty_to_na}{logical convert '' to NA_character_}
 }
 \description{
 Reads SAS data files

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -11,8 +11,8 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // readsas
-Rcpp::List readsas(const char * filePath, const bool debug, Nullable<IntegerVector> selectrows_, Nullable<CharacterVector> selectcols_);
-RcppExport SEXP _readsas_readsas(SEXP filePathSEXP, SEXP debugSEXP, SEXP selectrows_SEXP, SEXP selectcols_SEXP) {
+Rcpp::List readsas(const char * filePath, const bool debug, Nullable<IntegerVector> selectrows_, Nullable<CharacterVector> selectcols_, const bool empty_to_na);
+RcppExport SEXP _readsas_readsas(SEXP filePathSEXP, SEXP debugSEXP, SEXP selectrows_SEXP, SEXP selectcols_SEXP, SEXP empty_to_naSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -20,13 +20,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const bool >::type debug(debugSEXP);
     Rcpp::traits::input_parameter< Nullable<IntegerVector> >::type selectrows_(selectrows_SEXP);
     Rcpp::traits::input_parameter< Nullable<CharacterVector> >::type selectcols_(selectcols_SEXP);
-    rcpp_result_gen = Rcpp::wrap(readsas(filePath, debug, selectrows_, selectcols_));
+    Rcpp::traits::input_parameter< const bool >::type empty_to_na(empty_to_naSEXP);
+    rcpp_result_gen = Rcpp::wrap(readsas(filePath, debug, selectrows_, selectcols_, empty_to_na));
     return rcpp_result_gen;
 END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_readsas_readsas", (DL_FUNC) &_readsas_readsas, 4},
+    {"_readsas_readsas", (DL_FUNC) &_readsas_readsas, 5},
     {NULL, NULL, 0}
 };
 

--- a/src/readsas.cpp
+++ b/src/readsas.cpp
@@ -42,7 +42,8 @@ using namespace Rcpp;
 Rcpp::List readsas(const char * filePath,
                    const bool debug,
                    Nullable<IntegerVector> selectrows_,
-                   Nullable<CharacterVector> selectcols_)
+                   Nullable<CharacterVector> selectcols_,
+                   const bool empty_to_na)
 {
   std::ifstream sas(filePath, std::ios::in | std::ios::binary | std::ios::ate);
   auto sas_size = sas.tellg();
@@ -2155,16 +2156,17 @@ Rcpp::List readsas(const char * filePath,
               if (debug && i == 0)
                 Rcout << "writing: " << i << "/" << col << std::endl;
 
-              as<CharacterVector>(df[col])[i] = val_s;
+              if (empty_to_na && val_s.empty())
+                as<CharacterVector>(df[col])[i] = NA_STRING;
+              else
+                as<CharacterVector>(df[col])[i] = val_s;
+
             } else {
               skipahead += wid;
             }
           }
 
         }
-
-        // Rf_PrintValue(df);
-        // stop("stop");
 
         // end of row reached, skip to end if required
         if (skipahead > 0) {
@@ -2299,7 +2301,10 @@ Rcpp::List readsas(const char * filePath,
                 if (debug && i == 0)
                   Rcout << val_s << std::endl;
 
-                as<CharacterVector>(df[col])[i] = val_s;
+                if (empty_to_na && val_s.empty())
+                  as<CharacterVector>(df[col])[i] = NA_STRING;
+                else
+                  as<CharacterVector>(df[col])[i] = val_s;
 
               } else {
                 skipahead += wid;

--- a/src/readsas.cpp
+++ b/src/readsas.cpp
@@ -36,6 +36,7 @@ using namespace Rcpp;
 //' @param debug print debug information
 //' @param selectrows_ integer vector of selected rows
 //' @param selectcols_ character vector of selected rows
+//' @param empty_to_na logical convert '' to NA_character_
 //' @import Rcpp
 //' @export
 // [[Rcpp::export]]

--- a/tests/testthat/test_parso.R
+++ b/tests/testthat/test_parso.R
@@ -5,10 +5,10 @@ test_that("parso external tests", {
     "all_rand_uniform", "almost_rand", "comp_deleted", "data_page_with_deleted",
     "doubles", "doubles2", "extend_no", "extend_yes", "file_with_label",
     "fileserrors", "int_only", "int_only_partmissing",
-    # "mix_and_missing",                                # character "" is not imported as NA
+    "mix_and_missing",                                # character "" is not imported as NA
     "mix_data_misc", "mix_data_with_longchar",
-    # "mix_data_with_missing_char",                     # character "" is not imported as NA
-    # "mix_data_with_partmissing_char",                 # character "" is not imported as NA
+    "mix_data_with_missing_char",                     # character "" is not imported as NA
+    "mix_data_with_partmissing_char",                 # character "" is not imported as NA
     "mixed_data_one", "mixed_data_two",
     "only_datetime",
     # "test-columnar",                                  # formatted pct date, datetime and time
@@ -25,8 +25,21 @@ test_that("parso external tests", {
     # sas7bdat <- sprintf("~/Source/parso/src/test/resources/sas7bdat/%s.sas7bdat", fl)
     # csv      <- sprintf("~/Source/parso/src/test/resources/csv/%s.csv", fl)
 
-    got <- read.sas(sas7bdat, debug = FALSE)
-    exp <- read.csv(csv)
+    empty_to_na = FALSE
+
+    if (fl %in% c("mix_and_missing", "mix_data_with_missing_char", "mix_data_with_partmissing_char"))
+      empty_to_na = TRUE
+
+    got <- read.sas(sas7bdat, debug = FALSE, empty_to_na = empty_to_na)
+    exp <- read.csv(csv, na.strings = "NA")
+
+    # file is written with character missings. These are converted to integers. read.sas otherwise
+    # imports characters and read.csv imports integers and logical for entirely missing columns. This
+    # simply fixes the comparison, otherwise warnings regarding NA conversion would appear.
+    if (fl %in% c("mix_and_missing", "mix_data_with_missing_char", "mix_data_with_partmissing_char")) {
+      got <- as.data.frame(apply(got, 2, as.integer))
+      exp <- as.data.frame(apply(exp, 2, as.integer))
+    }
 
     expect_true(all.equal(got, exp, check.attributes = FALSE))
   }

--- a/tests/testthat/test_parso.R
+++ b/tests/testthat/test_parso.R
@@ -25,10 +25,10 @@ test_that("parso external tests", {
     # sas7bdat <- sprintf("~/Source/parso/src/test/resources/sas7bdat/%s.sas7bdat", fl)
     # csv      <- sprintf("~/Source/parso/src/test/resources/csv/%s.csv", fl)
 
-    empty_to_na = FALSE
+    empty_to_na <- FALSE
 
     if (fl %in% c("mix_and_missing", "mix_data_with_missing_char", "mix_data_with_partmissing_char"))
-      empty_to_na = TRUE
+      empty_to_na <- TRUE
 
     got <- read.sas(sas7bdat, debug = FALSE, empty_to_na = empty_to_na)
     exp <- read.csv(csv, na.strings = "NA")


### PR DESCRIPTION
In SAS any string that does not contain characters, is considered missing.

```sas
data tmp;
  s1 = '';
  s2 = ' ';
  s3 = '       ';
  m1 = missing(s1); * 1;
  m2 = missing(s2); * 1;
  m3 = missing(s3); * 1;
  t1 = .;
  t2 = .;
  t3 = .;
  if s1 = '' then t1 = 1; * 1;
  if s2 = ' ' then t2 = 1; * 1;
  if s3 = '' then t3 = 1; * 1;
run;
```

As shown in the snippet above, SAS is unable to compare different sizes of blank strings. Therefore it might be useful to convert any blank string to NA in R.
